### PR TITLE
Support base > 3

### DIFF
--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -13,8 +13,6 @@ module Control.Monad.Base (
 import Data.Monoid
 import Data.Functor.Identity
 import Control.Applicative (Applicative)
-import qualified Control.Monad.ST.Lazy as L
-import qualified Control.Monad.ST.Strict as S
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
@@ -28,7 +26,15 @@ import qualified Control.Monad.Trans.RWS.Lazy as L
 import qualified Control.Monad.Trans.RWS.Strict as S
 import Control.Monad.Trans.Error
 import Control.Monad.Trans.Cont
+
+#if MIN_VERSION_base(4,4,0)
+import qualified Control.Monad.ST.Lazy as L
+import qualified Control.Monad.ST.Strict as S
+#endif
+
+#if MIN_VERSION_base(4,3,0)
 import GHC.Conc.Sync (STM)
+#endif
 
 class (Applicative b, Applicative m, Monad b, Monad m)
       ⇒ MonadBase b m | m → b where
@@ -39,14 +45,21 @@ class (Applicative b, Applicative m, Monad b, Monad m)
 instance MonadBase (M) (M) where liftBase = id
 
 BASE(IO)
-BASE(L.ST s)
-BASE(S.ST s)
-BASE(STM)
 BASE(Maybe)
 BASE(Either e)
 BASE([])
 BASE((→) r)
 BASE(Identity)
+
+#if MIN_VERSION_base(4,3,0)
+BASE(STM)
+#endif
+
+#if MIN_VERSION_base(4,4,0)
+BASE(L.ST s)
+BASE(S.ST s)
+#endif
+
 #undef BASE
 
 -- | Can be used as a default implementation for 'liftBase'.

--- a/transformers-base.cabal
+++ b/transformers-base.cabal
@@ -29,7 +29,7 @@ Source-Repository head
 
 Library
   Build-Depends:
-    base          >= 4.4 && < 5,
+    base          >= 3 && < 5,
     transformers  >= 0.2
   Hs-Source-Dirs: src
   GHC-Options: -Wall


### PR DESCRIPTION
Hi Mikhail,

I just [released](http://hackage.haskell.org/package/monad-control-0.3) `monad-control` and already got my first [bug report](https://github.com/basvandijk/monad-control/issues/3) :-) about the package not building on older GHCs.

The attached patch lets `transformers-base` build from ghc-6.12.3 onwards.

It would be great if you can create a 0.4.0.1 release with this change.

Thanks,

Bas
