### PR TITLE
Support transformers-0.4.0.0

### DIFF
--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -5,6 +5,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+#if MIN_VERSION_transformers(0,4,0)
+-- Hide warnings for the deprecated ErrorT transformer:
+{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
+#endif
+
 module Control.Monad.Base (
     MonadBase(..),
     liftBaseDefault
@@ -26,6 +31,10 @@ import qualified Control.Monad.Trans.RWS.Lazy as L
 import qualified Control.Monad.Trans.RWS.Strict as S
 import Control.Monad.Trans.Error
 import Control.Monad.Trans.Cont
+
+#if MIN_VERSION_transformers(0,4,0)
+import Control.Monad.Trans.Except
+#endif
 
 #if !MIN_VERSION_base(4,4,0) && HS_TRANSFORMERS_BASE__ORPHANS
 import Control.Monad (ap)
@@ -92,6 +101,9 @@ TRANS(ReaderT r)
 TRANS(L.StateT s)
 TRANS(S.StateT s)
 TRANS(ContT r)
+#if MIN_VERSION_transformers(0,4,0)
+TRANS(ExceptT e)
+#endif
 #undef TRANS
 
 #define TRANS_CTX(CTX, T) \


### PR DESCRIPTION
Hi Mikhail,

It would be great if you can release this ASAP, so I can update monad-control and lifted-base.

I think we only need a minor version bump now according to the updated [PVP](http://www.haskell.org/haskellwiki/Package_versioning_policy) regarding instances. So I will let monad-control [depend](https://github.com/basvandijk/monad-control/commit/233537161fa9dd2c16b96aa4dfc88c0a640e83c3) on transformers-base-0.4.1.1.

Thanks!
