### PR TITLE
Unconditionally add ExceptT instance using transformers-compat

### DIFF
--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -36,9 +36,7 @@ import qualified Control.Monad.Trans.RWS.Strict as S
 import Control.Monad.Trans.Error
 import Control.Monad.Trans.Cont
 
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except
-#endif
 
 #if !MIN_VERSION_base(4,4,0) && HS_TRANSFORMERS_BASE__ORPHANS
 import Control.Monad (ap)
@@ -106,9 +104,7 @@ TRANS(ReaderT r)
 TRANS(L.StateT s)
 TRANS(S.StateT s)
 TRANS(ContT r)
-#if MIN_VERSION_transformers(0,4,0)
 TRANS(ExceptT e)
-#endif
 #undef TRANS
 
 #define TRANS_CTX(CTX, T) \

--- a/transformers-base.cabal
+++ b/transformers-base.cabal
@@ -34,9 +34,10 @@ Flag OrphanInstances
 
 Library
   Build-Depends:
-    base         >= 3 && < 5,
-    stm          >= 2.3,
-    transformers >= 0.2
+    base                >= 3 && < 5,
+    stm                 >= 2.3,
+    transformers        >= 0.2,
+    transformers-compat == 0.3.*
   Hs-Source-Dirs: src
   GHC-Options: -Wall
   if flag(OrphanInstances)


### PR DESCRIPTION
This is needed to allow reverse-dependencies to migrate to `ExceptT` using `transformers-compat` while keeping backwards compatibility for older versions of transformers.

