### PR TITLE
Import orphan Applicative instances from base-orphans

### DIFF
--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -37,9 +37,9 @@ import Control.Monad.Trans.Error
 import Control.Monad.Trans.Cont
 import Control.Monad.Trans.Except
 #if !MIN_VERSION_base(4,4,0) && HS_TRANSFORMERS_BASE__ORPHANS
-import Control.Monad (ap)
 import qualified Control.Monad.ST.Lazy as L
 import qualified Control.Monad.ST.Strict as S
+import Data.Orphans ()
 #endif
 #if MIN_VERSION_base(4,4,0)
 import qualified Control.Monad.ST.Lazy.Safe as L
@@ -65,14 +65,6 @@ BASE(Identity)
 BASE(STM)
 
 #if !MIN_VERSION_base(4,4,0) && HS_TRANSFORMERS_BASE__ORPHANS
-instance Applicative (L.ST s) where
-  pure  = return
-  (<*>) = ap
-
-instance Applicative (S.ST s) where
-  pure  = return
-  (<*>) = ap
-
 BASE(L.ST s)
 BASE(S.ST s)
 #endif

--- a/transformers-base.cabal
+++ b/transformers-base.cabal
@@ -29,7 +29,7 @@ Source-Repository head
 
 Flag OrphanInstances
   Description:
-    Declare orphan Applicative instances for lazy and strict ST if needed
+    Import orphan Applicative instances for lazy and strict ST if needed
   Default: True
 
 Library
@@ -41,6 +41,8 @@ Library
   Hs-Source-Dirs: src
   GHC-Options: -Wall
   if flag(OrphanInstances)
+    Build-Depends:
+      base-orphans >= 0.3
     CPP-Options: -DHS_TRANSFORMERS_BASE__ORPHANS=1
   else
     CPP-Options: -DHS_TRANSFORMERS_BASE__ORPHANS=0


### PR DESCRIPTION
Currently, `transformers-base` defines its own orphan `Applicative` instances for strict and lazy `ST`, which could duplicate instance conflicts if used with [other libraries](http://packdeps.haskellers.com/reverse/base-orphans) that indirectly export these instances. This commit imports these instances from `base-orphans` to avoid potential conflicts down the road.