### PR TITLE
Define default for `liftBase` with `liftBaseDefault`

### DIFF
--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE UnicodeSyntax #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UnicodeSyntax #-}
 
 #if MIN_VERSION_base(4,4,0)
 {-# LANGUAGE Safe #-}

--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UnicodeSyntax #-}
 
@@ -55,6 +57,8 @@ class (Applicative b, Applicative m, Monad b, Monad m)
       ⇒ MonadBase b m | m → b where
   -- | Lift a computation from the base monad
   liftBase ∷ b α → m α
+  default liftBase :: (m ~ t m', MonadTrans t, MonadBase b m') => b α → m α
+  liftBase = liftBaseDefault
 
 #define BASE(M) \
 instance MonadBase (M) (M) where liftBase = id
@@ -87,7 +91,7 @@ liftBaseDefault ∷ (MonadTrans t, MonadBase b m) ⇒ b α → t m α
 liftBaseDefault = lift . liftBase
 
 #define TRANS(T) \
-instance (MonadBase b m) ⇒ MonadBase b (T m) where liftBase = liftBaseDefault
+instance (MonadBase b m) ⇒ MonadBase b (T m)
 
 TRANS(IdentityT)
 TRANS(MaybeT)
@@ -101,7 +105,7 @@ TRANS(SelectT r)
 #undef TRANS
 
 #define TRANS_CTX(CTX, T) \
-instance (CTX, MonadBase b m) ⇒ MonadBase b (T m) where liftBase = liftBaseDefault
+instance (CTX, MonadBase b m) ⇒ MonadBase b (T m)
 
 TRANS_CTX(Monoid w, L.WriterT w)
 TRANS_CTX(Monoid w, S.WriterT w)


### PR DESCRIPTION
I figure there are more transformers than base monads, so this is the
more useful default than `id`.