### PR TITLE
Don't import Safe ST modules for modern versions of `base`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /cabal-dev
 /cabal.sandbox.config
 /dist
-/dist-newstyle
+/dist-*
 .*
 *~

--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -47,14 +47,18 @@ import Data.Monoid
 import Control.Applicative (Applicative(..))
 #endif
 #if !MIN_VERSION_base(4,4,0) && HS_TRANSFORMERS_BASE__ORPHANS
-import Data.Orphans ()
-#endif
-#if MIN_VERSION_base(4,4,0) && !MIN_VERSION_base(4,8,0)
-import qualified Control.Monad.ST.Lazy.Safe as L
-import qualified Control.Monad.ST.Safe as S
-#else
 import qualified Control.Monad.ST.Lazy as L
 import qualified Control.Monad.ST.Strict as S
+import Data.Orphans ()
+#endif
+#if MIN_VERSION_base(4,4,0)
+# if MIN_VERSION_base(4,8,0)
+import qualified Control.Monad.ST.Lazy as L
+import qualified Control.Monad.ST.Strict as S
+# else
+import qualified Control.Monad.ST.Lazy.Safe as L
+import qualified Control.Monad.ST.Safe as S
+# endif
 #endif
 import Control.Monad.STM (STM)
 

--- a/src/Control/Monad/Base.hs
+++ b/src/Control/Monad/Base.hs
@@ -47,13 +47,14 @@ import Data.Monoid
 import Control.Applicative (Applicative(..))
 #endif
 #if !MIN_VERSION_base(4,4,0) && HS_TRANSFORMERS_BASE__ORPHANS
-import qualified Control.Monad.ST.Lazy as L
-import qualified Control.Monad.ST.Strict as S
 import Data.Orphans ()
 #endif
-#if MIN_VERSION_base(4,4,0)
+#if MIN_VERSION_base(4,4,0) && !MIN_VERSION_base(4,8,0)
 import qualified Control.Monad.ST.Lazy.Safe as L
 import qualified Control.Monad.ST.Safe as S
+#else
+import qualified Control.Monad.ST.Lazy as L
+import qualified Control.Monad.ST.Strict as S
 #endif
 import Control.Monad.STM (STM)
 


### PR DESCRIPTION
`Control.Monad.ST.Safe` and `Control.Monad.ST.Lazy.Safe` are deprecated since `base-4.8`, so only import them for older`base` versions. I think it would be reasonable to drop support for `base < 4.8`, as that would allow to get rid of a bunch of CPP, but I have not done that in this PR.

With this change, `transformers-base` compiles with [MicroHs](https://github.com/augustss/MicroHs), so update the `.gitignore` to also match `dist-mcabal`.